### PR TITLE
Use sin_cos

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2,13 +2,14 @@ mod cyclotomic;
 mod cassels;
 
 use cassels::loop_over_roots;
+use cyclotomic::test_cyclotomic_integer_exponents;
 
 use std::fs::File;
 
 fn main() -> std::io::Result<()> {
     // This should be handled somewhere else:
-    // test_cyclotomic_integer_exponents();
-    // println!("All tests passed!");
+    test_cyclotomic_integer_exponents();
+    println!("All tests passed!");
 
     let file_tables = File::create("tables.txt")?;
     let file_output = File::create("output.txt")?;


### PR DESCRIPTION
We use the `f64::sin_cos` method.

The change is relatively straightforward, as one essentially only has to change `(Vec<f64>, Vec<f64>)` to `Vec<(f64, f64)>`, which seems better anyway (sin and cos values are grouped, allows for pattern matching, etc).

One has to be a bit careful with _variable shadowing_ (see comment on line 100 of `cyclotomic.rs`).

And at some point, the comment on line 22 of `cassels.rs` should be addressed, or explicitly not addressed.